### PR TITLE
Updating react-router to 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "keymirror": "^0.1.1",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.6",
-    "react": "^15.4.2",
-    "react-router": "3.0.2",
+    "react": "^15.5.4",
+    "react-router": "^4.1.1",
     "toastr": "^2.1.2",
     "vinyl-source-stream": "^1.1.0"
   },


### PR DESCRIPTION

Please update [react-router](https://npmjs.org/package/react-router) to version 4.1.1.

If this passes your tests you can merge it in.  If not please use this branch for changes.

